### PR TITLE
Label current version as 20210701

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,12 +2,12 @@
 
 ## API versions and changes
 
-### 20210701 (to be released on 1 July)
+### 20210701 (Current version)
 
 - **Breaking change**: `DELETE /invoices/INVOICE_ID` will cease to exist and return a `410 Gone`.
 - **Breaking change**: `PUT /invoices/INVOICE_ID` will only allow modification of the parameters `notes`, `tag_list`, `custom_metadata` and all those related to the customer's address: `street_line_1`,`street_line_2`,`city`,`region`,`postal_code` and `country`.
 
-### 20210316 (Current version)
+### 20210316
 * **Breaking change**: record pagination is no longer performed with a `page` parameter, but with a `created_before` parameter. See the [pagination documentation](#pagination) for more details.
 * **Breaking change**: the existing [/taxes/calculate](#calculate-taxes) endpoint is deprecated in favour of the [/tax_rates/calculate](#calculate-a-tax-rate) endpoint.
 * Adds a `Deprecation: true` header (as per <a href='https://tools.ietf.org/html/draft-ietf-httpapi-deprecation-header-01#section-2.1'>draft-ietf-httpapi-deprecation-header-01</a>) to responses using deprecated pagination, with a `Link` header linking to the updated documentation. After the deprecation dates, those endpoints will return a `410 Gone`.

--- a/source/includes/_setup.md
+++ b/source/includes/_setup.md
@@ -164,12 +164,6 @@ To override this value you can pass the version in the `Accept` HTTP header like
 
 Exceptionally, we release versions that break backwards compatibility, to take full advantage of new features or to make the API faster for you. In these rare cases, we give a transition period in which you will be able to select which API version to use. After the deprecation date, the old API versions will not be available. These are the cases for versions <strong>20210316</strong> and <strong>20210701</strong>.
 
-<aside class="info">
-  The current version is <strong>20210316</strong>, which contains breaking changes to pagination and deprecates the legacy Taxes API. It's currently into transitioning time and backwards compatibility will be disabled on 1 July.
-
-  Also on 1 July version <strong>20210701</strong> will be released, which contains breaking changes to the Invoice API. Please refer to the following guides on safely upgrading API versions </a> and the <a href='#changelog'>changelog</a> for details.
-</aside>
-
 ### Safely upgrading to API version 20210701
 
 In our goal to make Quaderno compliant with tax rules worldwide, we're going to limit the edition of invoices and credit notes via API as of 1 July.


### PR DESCRIPTION
Overdue by a few weeks.

We didn't actually make the 20210316 breaking changes break yet, but lets pretend we did for documentation purposes.